### PR TITLE
Add Platform Name to config.schema.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 
 
-[Homebridge](https://homebridge.io) Plugin Providing [Remootio](https://www.remootio.com/) Support. This plugin supports both [Remootio 1](https://www.remootio.com/products/remootio) and [Remootio 2](https://www.remootio.com/products/remootio) with software version >=2.23 that provides the new [V2 API](https://github.com/remootio/remootio-api-documentation/blob/master/websocket_api_v2_specification.md).
+[Homebridge](https://homebridge.io) Plugin Providing [Remootio](https://www.remootio.com/) Support. This plugin supports <B>Remootio 1</B>, <B>Remootio 2</B> and <B>Remootio 3</B> with software version >=2.23 that provides the new [V2 API](https://github.com/remootio/remootio-api-documentation/blob/master/websocket_api_v2_specification.md).
 
 ## Usage
 First of all make sure that the Remootio Websocket API is enabled `with logging` for your Remootio device in the Remootio app. Please take note of the API Secret Key and API Auth Key along with the IP address of the device, as you will need these. Install the `Gate status sensor` and enable it in the app.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 # Homebridge Remootio
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 <a href="https://www.npmjs.com/package/homebridge-remootio"><img title="npm version" src="https://badgen.net/npm/v/homebridge-remootio" ></a>
+[![npm](https://badgen.net/npm/dt/homebridge-remootio?label=downloads)](https://www.npmjs.com/package/homebridge-remootio)
 
 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you are new to Homebridge, please first read the [Homebridge](https://homebri
 "platforms": [
     {
         "platform": "Remootio",
+        "name": "Remootio",
         "devices": [
             {
                 "name": "<name of the device you want to appear in HomeKit>",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,44 +1,52 @@
 {
-  "pluginAlias": "Remootio",
-  "pluginType": "platform",
-  "singular": true,
-  "schema": {
-    "devices": {
-      "type": "array",
-      "items": {
-        "title": "Remootio device",
+    "pluginAlias": "Remootio",
+    "pluginType": "platform",
+    "singular": true,
+    "schema": {
         "type": "object",
         "properties": {
-          "name": {
-            "title": "Name",
-            "type": "string",
-            "required": true,
-            "default": "Remootio Accessory"
-          },
-          "ipAddress": {
-            "title": "IP Address",
-            "description": "The device's IP address. It is recommended to set a static IP for the device.",
-            "type": "string",
-            "format": "ipv4",
-            "required": true,
-            "default": "192.168.1.0"
-          },
-          "apiSecretKey": {
-            "title": "API Secret Key",
-            "description": "The device's API Secret Key ",
-            "type": "string",
-            "required": true,
-            "default": ""
-          },
-          "apiAuthKey": {
-            "title": "API Authentication Key",
-            "description": "The device's API Authentication Key ",
-            "type": "string",
-            "required": true,
-            "default": ""
-          }
+            "name": {
+                "title": "Name",
+                "type": "string",
+                "default": "Remootio"
+            },
+            "devices": {
+                "type": "array",
+                "items": {
+                    "title": "Remootio device",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Name",
+                            "type": "string",
+                            "required": true,
+                            "default": "Remootio Accessory"
+                        },
+                        "ipAddress": {
+                            "title": "IP Address",
+                            "description": "The device's IP address. It is recommended to set a static IP for the device.",
+                            "type": "string",
+                            "format": "ipv4",
+                            "required": true,
+                            "default": "192.168.1.0"
+                        },
+                        "apiSecretKey": {
+                            "title": "API Secret Key",
+                            "description": "The device's API Secret Key ",
+                            "type": "string",
+                            "required": true,
+                            "default": ""
+                        },
+                        "apiAuthKey": {
+                            "title": "API Authentication Key",
+                            "description": "The device's API Authentication Key ",
+                            "type": "string",
+                            "required": true,
+                            "default": ""
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
Hey @ronniepettersson, I had found a minor bug/issue while using your plug-in (otherwise works perfectly!). I found unlike other plug-ins I have installed that in my homebridge logs it would show the platform name as the full plug-in name `homebridge-remootio` instead of something like `Remootio`; I found this was the same for the name when creating a Child Bridge.

## Before:
Shows an example of Remootio vs Roborock plug-in:

```shell
[04/02/2022, 2:33:06 pm] [homebridge-remootio] Remootio platform finished initializing!
[04/02/2022, 2:33:06 pm] [homebridge-remootio] Configuring accessory Garage Door
[04/02/2022, 2:33:06 pm] [homebridge-remootio] Remotio platform didFinishLaunching()
[04/02/2022, 2:33:06 pm] [homebridge-remootio] [Garage Door] Finished initializing!
[04/02/2022, 2:33:06 pm] Homebridge v1.4.0 (HAP v0.10.0) (homebridge-remootio) is running on port 34390.
[04/02/2022, 2:33:06 pm] [homebridge-remootio] [Garage Door] Connected
[04/02/2022, 2:33:06 pm] [homebridge-remootio] [Garage Door] Setting current state to CLOSED
[04/02/2022, 2:33:06 pm] [homebridge-remootio] [Garage Door] Authenticated
[04/02/2022, 2:33:06 pm] Registering accessory 'homebridge-xiaomi-roborock-vacuum.XiaomiRoborockVacuum'
[04/02/2022, 2:33:06 pm] [Roborock] Loaded homebridge-xiaomi-roborock-vacuum v0.20.1 child bridge successfully
```
Shows an example of Child Bridges:

![image](https://user-images.githubusercontent.com/40288237/152485793-026b5d2b-584d-4ce1-9058-85df44416961.png)

## Proposed Change:
The `"name"` parameter needs to be added to the platform directives of the `config.json` (which can already be added without this PR):

```json
"platforms": [
    {
        "platform": "Remootio",
        "name": "Remootio",
        "devices": [
            {
                "name": "<name of the device you want to appear in HomeKit>",
                "ipAddress": "<the ip address of your Remootio device>",
                "apiSecretKey": "<API Secret Key>",
                "apiAuthKey": "<API Auth Key>"
            },
                {
                "name": "<name of the device you want to appear in HomeKit>",
                "ipAddress": "<the ip address of your Remootio device>",
                "apiSecretKey": "<API Secret Key>",
                "apiAuthKey": "<API Auth Key>"
            },
        ]
    }
]
```
However, what I have changed in this PR is to add this field to the `config.schema.json` (it has been left as not 'required' so as not break existing setups) so that users are prompted to add it. It has also been modified in your `README` for users who still just copy/paste a config sample.

## After:
Shows a example of plug-in name in Homebridge logs after change:

```shell
[04/02/2022, 3:08:11 pm] [Remootio] [Garage Door] Setting current state to CLOSED
[04/02/2022, 3:08:11 pm] [Remootio] [Garage Door] Authenticated
[04/02/2022, 3:08:11 pm] [Wiz] Loading accessory from cache: Wiz Tunable White Bulb XXXXXXX
```
Shows an example of Child Bridges after change:

![image](https://user-images.githubusercontent.com/40288237/152487066-d08b7382-33ef-4414-b69d-03d4da41d784.png)

Shows an example of how the `config.schema.json` looks after change:

![image](https://user-images.githubusercontent.com/40288237/152487293-8e39170f-4fef-45c0-9357-728eb60bbc50.png)

## What's Left:
I have left bumping the version number for the plug-in for you if you accept this PR. This has been tested and is all working on my setup; let me know if you have any questions :)